### PR TITLE
Remove URL Regex unused dependency

### DIFF
--- a/SpiderPig.js
+++ b/SpiderPig.js
@@ -1,5 +1,4 @@
 const puppeteer = require("puppeteer");
-// const urlRegex = require("url-regex");
 const normalizeUrl = require("normalize-url");
 const { URL } = require("url");
 const debug = require("debug")("SpiderPig");

--- a/package.json
+++ b/package.json
@@ -37,10 +37,16 @@
     "url-regex": "^4.1.1"
   },
   "devDependencies": {
-    "ava": "^0.24.0",
+    "ava": "^3.15.0",
     "connect": "^3.6.5",
     "debug": "^3.1.0",
+    "esm": "^3.2.25",
     "pify": "^3.0.0",
     "serve-static": "^1.13.1"
+  },
+  "ava": {
+    "require": [
+      "esm"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "chalk": "^2.3.0",
     "minimist": "^1.2.0",
     "normalize-url": "^2.0.1",
-    "puppeteer": "^1.0.0",
-    "url-regex": "^4.1.1"
+    "puppeteer": "^1.0.0"
   },
   "devDependencies": {
     "ava": "^3.15.0",


### PR DESCRIPTION
This removes the unused URL Regex dependency.

* Used VSCode to search for `url-regex` confirmed it was commented out in JS files
* Removed from package.json
* Updated lockfile (noticed you do not use so not comitted)
* Run tests

Please ignore Ava and esm, these are part of another PR. If you wish for me to remove those changes from this PR, I can rebase them out.