### PR TITLE
Bump Ava from 0.x to 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,10 +37,16 @@
     "url-regex": "^4.1.1"
   },
   "devDependencies": {
-    "ava": "^0.24.0",
+    "ava": "^3.15.0",
     "connect": "^3.6.5",
     "debug": "^3.1.0",
+    "esm": "^3.2.25",
     "pify": "^3.0.0",
     "serve-static": "^1.13.1"
+  },
+  "ava": {
+    "require": [
+      "esm"
+    ]
   }
 }


### PR DESCRIPTION
This addresses warnings about vulnerabilities by upgrading ava to the latest version

* Increased version
* Noticed tests not working
* Checked Ava docs
* Added esm module to ava
* Noticed tests still not working but different error
* Added esm to dev dependencies
* Run tests, they work

This is also included in #6 whatever is easier for you, but if you'd like both, maybe best to merge it and this will auto-close, unless you want it removed from those work, then there are two PR's. 🤷 