### PR TITLE
Update URI schemes

### DIFF
--- a/SpiderPig.js
+++ b/SpiderPig.js
@@ -50,6 +50,7 @@ class SpiderPig {
 		   	url.indexOf( "sms:" ) === 0 || 
 		   	url.indexOf( "fax:" ) === 0 || 
 		   	url.indexOf( "callto:" ) === 0 || 
+		   	url.indexOf( "javascript:" ) === 0 || 
 			!this.isLocalHref(url, origin) ) {
 
 			return false;

--- a/SpiderPig.js
+++ b/SpiderPig.js
@@ -46,6 +46,10 @@ class SpiderPig {
 		if( !url ||
 			this.duplicates[ url ] ||
 			url.indexOf( "mailto:" ) === 0 || // is email link
+		   	url.indexOf( "tel:" ) === 0 || 
+		   	url.indexOf( "sms:" ) === 0 || 
+		   	url.indexOf( "fax:" ) === 0 || 
+		   	url.indexOf( "callto:" ) === 0 || 
 			!this.isLocalHref(url, origin) ) {
 
 			return false;


### PR DESCRIPTION
Add more conditions to ignore URI schemes like `tel:` and `sms:`.
Fixes #8 

The list is big, and I just included the ones I think are more frequent:
https://en.wikipedia.org/wiki/List_of_URI_schemes
(maybe we can check if the link is relative, or an absolute one starting with `http://` or `https://` instead of blacklisting all schemes 🤔)